### PR TITLE
refactor(plugin): zodToTsをts-morphに移行し、スキーマ解析を強化

### DIFF
--- a/.docs/initialDocs/design.md
+++ b/.docs/initialDocs/design.md
@@ -9,14 +9,13 @@
 
 - **ファイルベースルーティング**: `src/pages/` 以下の構造をルートに変換
 - **ネストされたルート (レイアウト機能)**: `_layout.tsx` による共通レイアウト、`_root.tsx` によるルート提示、`_404.tsx` による見つからないページのフォールバック
-- **柔軟 params DSL**: ページごとに `params` を宣言し、必須/任意、enum、配列、ネストオブジェクトを表現可能
+- **Zod スキーマ対応**: `export const schema = z.object(...)` による型定義とバリデーション
 - **型安全なパスパラメータ**: 動的ルートのパスパラメータも型付けされ、フックで取得可能
 - **型安全な navigate**: `router.navigate("pageName", params)` が IDE 補完される
 - **ナビゲーションガード**: 認証状態のチェックや、フォームの未保存データを警告するなど、ルート遷移を制御する仕組み
 - **フレームワーク対応**: React Hooks と Vue Composables の両方を提供
 - **環境抽象化**: GAS とブラウザの両方に対応
-- **Vite プラグイン**: ルートと params から `.d.ts` を自動生成
-- **Zod スキーマ対応**: `export const schema = z.object(...)` による型定義とバリデーション
+- **Vite プラグイン**: ルートと Zod スキーマから `.d.ts` を自動生成
 
 ---
 
@@ -36,7 +35,7 @@
   - Browser Adapter: `window.location`, `window.history`
 - **Vite Plugin**
   - `src/pages/**/*.{tsx,vue}` を探索
-  - `params` DSL と動的パスパラメータを解析し、型定義 (`.generated/router.d.ts`) を生成
+  - `export const schema` (Zod スキーマ) を解析し、型定義 (`.generated/router.d.ts`) を生成
   - ルートとコンポーネントのマッピング情報 (`.generated/routes.ts`) を生成
   - ルート競合の解決: `index` ファイル（例: `test/index.tsx`）を通常ファイル（例: `test.tsx`）より優先する。
   - HMR キャッシュ: ファイルI/OとAST解析を最小限にするため、インメモリキャッシュ（ファイル最終更新日時、解析結果）を保持する。
@@ -49,8 +48,8 @@
 ## 3. データフロー
 
 1. **開発時**
-   - 開発者が `src/pages/xxx.tsx` または `xxx.vue` に `params` DSL を定義
-   - Vite プラグインが DSL とファイル構造を解析し、`.generated/router.d.ts` (型) と `.generated/routes.ts` (コンポーネントマップ) を生成
+   - 開発者が `src/pages/xxx.tsx` または `xxx.vue` に `export const schema` (Zod スキーマ) を定義
+   - Vite プラグインがスキーマとファイル構造を解析し、`.generated/router.d.ts` (型) と `.generated/routes.ts` (コンポーネントマップ) を生成
    - IDE 補完が有効化される
 
 2. **実行時**
@@ -63,7 +62,7 @@
 
 ---
 
-## 4. DSL → TypeScript 型変換ルール
+## 4. Zod スキーマ → TypeScript 型変換ルール
 
 ### Zod スキーマからの型推論
 
@@ -158,8 +157,8 @@ src/
 │   ├─ gas.ts           # GAS Adapter
 │   └─ index.ts         # Adapter 切替
 ├─ plugin/
-│   ├─ dslToTs.ts       # DSL → TS 型変換
 │   ├─ generator.ts     # 型ファイル生成ロジック
+│   ├─ zodToTs.ts       # Zod → TS 型変換
 │   └─ index.ts         # Vite プラグインエントリ
 └─ index.ts             # ライブラリエントリ
 ```

--- a/.docs/initialDocs/requirements.md
+++ b/.docs/initialDocs/requirements.md
@@ -77,9 +77,7 @@ export interface RouteParams {
 
 ---
 
-## 柔軟 DSL の仕様
-
-### サポートする型表現 (Zod)
+## Zod スキーマの仕様
 
 Zod スキーマを使用してパラメータを定義します。
 
@@ -193,13 +191,6 @@ router.beforeEach((to, from, next) => {
 - HMR時のパフォーマンス最適化（ファイルI/O削減）:
   - 変更のないファイルのAST解析をスキップするため、ファイルキャッシュ（mtime, 解析結果）を導入する。
   - 生成される型定義やルートマップの内容が前回と同一の場合、ファイル書き込み（writeFileSync）をスキップする。
-
-### 変換ロジック (再帰)
-
-- プリミティブ: `"string" → string`, `"string?" → string | undefined`
-- enum: `values` を union 型に展開
-- array: `items` を再帰的に展開し `T[]`
-- object: `shape` を再帰的に展開し `{ ... }`
 
 ---
 

--- a/.docs/initialDocs/tasks.md
+++ b/.docs/initialDocs/tasks.md
@@ -42,8 +42,8 @@
 ## Vite Plugin
 
 - [x] **ページ探索**: `src/pages/**/*.{tsx,vue}` を `fast-glob` で探索
-- [x] **AST 解析**: `export const params` を `typescript` で解析・抽出
-- [x] **DSL → TS 型変換**: `dslToTs` 再帰関数による型定義文字列の生成
+- [x] **AST 解析**: `export const schema` を `ts-morph` で解析・抽出
+- [x] **Zod → TS 型変換**: `zodToTs` 関数による型定義文字列の生成
 - [x] **型ファイル生成**: `router.d.ts` と `routes.ts` を生成・書き出し
 - [x] **HMR 対応**: ファイル変更を監視し、型ファイルを即時再生成
 - [x] **動的パスパラメータ**: `[param].tsx` などのパスパラメータを解析し、型生成に統合

--- a/build.config.ts
+++ b/build.config.ts
@@ -32,7 +32,7 @@ export default defineBuildConfig({
   externals: [
     'vite',
     'fast-glob',
-    'typescript',
+    'ts-morph',
     'react',
     'react-dom',
     'vue',

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@ciderjs/city-gas",
-  "version": "1.0.0",
+  "version": "1.1.0",
   "description": "Router for Single Page App on Google Apps Script",
   "main": "dist/index.mjs",
   "types": "dist/index.d.ts",
@@ -49,7 +49,7 @@
   "dependencies": {
     "@vue/compiler-sfc": "^3.5.22",
     "fast-glob": "^3.3.3",
-    "typescript": "^5.9.3"
+    "ts-morph": "^27.0.2"
   },
   "devDependencies": {
     "@biomejs/biome": "^2.3.2",
@@ -68,6 +68,7 @@
     "jsdom": "^27.1.0",
     "react": "^19.2.0",
     "react-dom": "^19.2.0",
+    "typescript": "^5.9.3",
     "unbuild": "^3.6.1",
     "vite": "^7.1.12",
     "vite-tsconfig-paths": "^5.1.4",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -14,9 +14,9 @@ importers:
       fast-glob:
         specifier: ^3.3.3
         version: 3.3.3
-      typescript:
-        specifier: ^5.9.3
-        version: 5.9.3
+      ts-morph:
+        specifier: ^27.0.2
+        version: 27.0.2
     devDependencies:
       '@biomejs/biome':
         specifier: ^2.3.2
@@ -66,6 +66,9 @@ importers:
       react-dom:
         specifier: ^19.2.0
         version: 19.2.0(react@19.2.0)
+      typescript:
+        specifier: ^5.9.3
+        version: 5.9.3
       unbuild:
         specifier: ^3.6.1
         version: 3.6.1(typescript@5.9.3)(vue@3.5.22(typescript@5.9.3))
@@ -434,6 +437,14 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@isaacs/balanced-match@4.0.1':
+    resolution: {integrity: sha512-yzMTt9lEb8Gv7zRioUilSglI0c0smZ9k5D65677DLWLtWJaXIS3CqcGyUFByYKlnUj6TkjLVs54fBl6+TiGQDQ==}
+    engines: {node: 20 || >=22}
+
+  '@isaacs/brace-expansion@5.0.0':
+    resolution: {integrity: sha512-ZT55BDLV0yv0RBm2czMiZ+SqCGO7AvmOM3G/w2xhVPH+te0aKgFjmBvGlL1dH+ql2tgGO3MVrbb3jCKyvpgnxA==}
+    engines: {node: 20 || >=22}
+
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
     engines: {node: '>=12'}
@@ -671,6 +682,9 @@ packages:
         optional: true
       '@types/react-dom':
         optional: true
+
+  '@ts-morph/common@0.28.1':
+    resolution: {integrity: sha512-W74iWf7ILp1ZKNYXY5qbddNaml7e9Sedv5lvU1V8lftlitkc9Pq1A+jlH23ltDgWYeZFFEqGCD1Ies9hqu3O+g==}
 
   '@types/aria-query@5.0.4':
     resolution: {integrity: sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==}
@@ -945,6 +959,9 @@ packages:
 
   citty@0.1.6:
     resolution: {integrity: sha512-tskPPKEs8D2KPafUypv2gxwJP8h/OaJmC82QQGGDQcHvXX43xF2VDACcJVmZ0EuSxkpO9Kc4MlrA3q0+FG58AQ==}
+
+  code-block-writer@13.0.3:
+    resolution: {integrity: sha512-Oofo0pq3IKnsFtuHqSF7TqBfr71aeyZDVJ0HpmqB7FBM2qEigL0iPONSCZSO9pE9dZTAxANe5XHG9Uy0YMv8cg==}
 
   color-convert@2.0.1:
     resolution: {integrity: sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==}
@@ -1385,6 +1402,10 @@ packages:
     resolution: {integrity: sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==}
     engines: {node: '>=4'}
 
+  minimatch@10.1.1:
+    resolution: {integrity: sha512-enIvLvRAFZYXJzkCYG5RKmPfrFArdLv+R+lbQ53BmIMLIry74bjKzX6iHAm8WYamJkhSSEabrWN5D97XnKObjQ==}
+    engines: {node: 20 || >=22}
+
   minimatch@9.0.1:
     resolution: {integrity: sha512-0jWhJpD/MdhPXwPuiRkCbfYfSKp2qnn2eOc279qI7f+osl/l+prKSrvhg157zSYvx/1nmgn2NqdT6k2Z7zSH9w==}
     engines: {node: '>=16 || 14 >=14.17'}
@@ -1453,6 +1474,9 @@ packages:
 
   parse5@8.0.0:
     resolution: {integrity: sha512-9m4m5GSgXjL4AjumKzq1Fgfp3Z8rsvjRNbnkVwfu2ImRqE5D0LnY2QfDen18FSY9C573YU5XxSapdHZTZ2WolA==}
+
+  path-browserify@1.0.1:
+    resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
   path-key@3.1.1:
     resolution: {integrity: sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==}
@@ -1862,6 +1886,9 @@ packages:
   tr46@6.0.0:
     resolution: {integrity: sha512-bLVMLPtstlZ4iMQHpFHTR7GAGj2jxi8Dg0s2h2MafAE4uSWF98FC/3MomU51iQAMf8/qDUbKWf5GxuvvVcXEhw==}
     engines: {node: '>=20'}
+
+  ts-morph@27.0.2:
+    resolution: {integrity: sha512-fhUhgeljcrdZ+9DZND1De1029PrE+cMkIP7ooqkLRTrRLTqcki2AstsyJm0vRNbTbVCNJ0idGlbBrfqc7/nA8w==}
 
   tsconfck@3.1.6:
     resolution: {integrity: sha512-ks6Vjr/jEw0P1gmOVwutM3B7fWxoWBL2KRDb1JfqGVawBmO5UsvmWOQFGHBPl5yxYz4eERr19E6L7NMv+Fej4w==}
@@ -2337,6 +2364,12 @@ snapshots:
   '@esbuild/win32-x64@0.25.11':
     optional: true
 
+  '@isaacs/balanced-match@4.0.1': {}
+
+  '@isaacs/brace-expansion@5.0.0':
+    dependencies:
+      '@isaacs/balanced-match': 4.0.1
+
   '@isaacs/cliui@8.0.2':
     dependencies:
       string-width: 5.1.2
@@ -2532,6 +2565,12 @@ snapshots:
     optionalDependencies:
       '@types/react': 19.2.2
       '@types/react-dom': 19.2.2(@types/react@19.2.2)
+
+  '@ts-morph/common@0.28.1':
+    dependencies:
+      minimatch: 10.1.1
+      path-browserify: 1.0.1
+      tinyglobby: 0.2.15
 
   '@types/aria-query@5.0.4': {}
 
@@ -2850,6 +2889,8 @@ snapshots:
   citty@0.1.6:
     dependencies:
       consola: 3.4.2
+
+  code-block-writer@13.0.3: {}
 
   color-convert@2.0.1:
     dependencies:
@@ -3309,6 +3350,10 @@ snapshots:
 
   min-indent@1.0.1: {}
 
+  minimatch@10.1.1:
+    dependencies:
+      '@isaacs/brace-expansion': 5.0.0
+
   minimatch@9.0.1:
     dependencies:
       brace-expansion: 2.0.2
@@ -3368,6 +3413,8 @@ snapshots:
   parse5@8.0.0:
     dependencies:
       entities: 6.0.1
+
+  path-browserify@1.0.1: {}
 
   path-key@3.1.1: {}
 
@@ -3761,6 +3808,11 @@ snapshots:
   tr46@6.0.0:
     dependencies:
       punycode: 2.3.1
+
+  ts-morph@27.0.2:
+    dependencies:
+      '@ts-morph/common': 0.28.1
+      code-block-writer: 13.0.3
 
   tsconfck@3.1.6(typescript@5.9.3):
     optionalDependencies:

--- a/tests/plugin/zodToTs.spec.ts
+++ b/tests/plugin/zodToTs.spec.ts
@@ -1,181 +1,127 @@
-import ts from 'typescript';
+import { type Expression, Project } from 'ts-morph';
 import { describe, expect, it } from 'vitest';
 import { zodToTs } from '@/plugin/zodToTs';
 
-function parseExpression(code: string): {
-  node: ts.Expression;
-  sourceFile: ts.SourceFile;
-} {
-  const sourceFile = ts.createSourceFile(
-    'test.ts',
-    code,
-    ts.ScriptTarget.Latest,
-    true,
-  );
+const project = new Project();
 
-  // ExpressionStatementのexpressionを取得
-  const statement = sourceFile.statements[0] as ts.ExpressionStatement;
-  return { node: statement?.expression, sourceFile };
+function parseExpression(code: string): Expression {
+  const sourceFile = project.createSourceFile(
+    'test.ts',
+    `const schema = ${code};`,
+    { overwrite: true },
+  );
+  const declaration = sourceFile.getVariableDeclaration('schema');
+  return declaration?.getInitializer() as Expression;
 }
 
 describe('zodToTs', () => {
   describe('Primitives', () => {
     it('should convert primitive types', () => {
-      const { node, sourceFile } = parseExpression('z.string()');
-      expect(zodToTs(node, sourceFile)).toBe('string');
+      const node = parseExpression('z.string()');
+      expect(zodToTs(node)).toBe('string');
     });
 
     it('should convert number and boolean', () => {
-      expect(
-        zodToTs(
-          parseExpression('z.number()').node,
-          parseExpression('').sourceFile,
-        ),
-      ).toBe('number');
-      expect(
-        zodToTs(
-          parseExpression('z.boolean()').node,
-          parseExpression('').sourceFile,
-        ),
-      ).toBe('boolean');
+      expect(zodToTs(parseExpression('z.number()'))).toBe('number');
+      expect(zodToTs(parseExpression('z.boolean()'))).toBe('boolean');
     });
 
     it('should convert any, unknown, void', () => {
-      expect(
-        zodToTs(
-          parseExpression('z.any()').node,
-          parseExpression('').sourceFile,
-        ),
-      ).toBe('any');
-      expect(
-        zodToTs(
-          parseExpression('z.unknown()').node,
-          parseExpression('').sourceFile,
-        ),
-      ).toBe('unknown');
+      expect(zodToTs(parseExpression('z.any()'))).toBe('any');
+      expect(zodToTs(parseExpression('z.unknown()'))).toBe('unknown');
     });
   });
 
   describe('Modifiers', () => {
     it('should handle optional', () => {
-      // Input型としては string | undefined
-      const { node, sourceFile } = parseExpression('z.string().optional()');
-      expect(zodToTs(node, sourceFile)).toBe('string | undefined');
+      const node = parseExpression('z.string().optional()');
+      expect(zodToTs(node)).toBe('string | undefined');
     });
 
     it('should handle nullable', () => {
-      const { node, sourceFile } = parseExpression('z.number().nullable()');
-      expect(zodToTs(node, sourceFile)).toBe('number | null');
+      const node = parseExpression('z.number().nullable()');
+      expect(zodToTs(node)).toBe('number | null');
     });
 
     it('should handle nullish (optional + nullable)', () => {
-      const { node, sourceFile } = parseExpression('z.string().nullish()');
-      const res = zodToTs(node, sourceFile);
-      // string | null | undefined (順序は実装依存だが含まれているか確認)
+      const node = parseExpression('z.string().nullish()');
+      const res = zodToTs(node);
       expect(res).toContain('string');
       expect(res).toContain('null');
       expect(res).toContain('undefined');
     });
 
     it('should treat .default() as optional for input', () => {
-      const { node, sourceFile } = parseExpression('z.string().default("foo")');
-      expect(zodToTs(node, sourceFile)).toBe('string | undefined');
+      const node = parseExpression('z.string().default("foo")');
+      expect(zodToTs(node)).toBe('string | undefined');
     });
   });
 
   describe('Coercion', () => {
     it('should handle z.coerce.number()', () => {
-      const { node, sourceFile } = parseExpression('z.coerce.number()');
-      expect(zodToTs(node, sourceFile)).toBe('number');
+      const node = parseExpression('z.coerce.number()');
+      expect(zodToTs(node)).toBe('number');
     });
 
     it('should handle z.coerce.boolean().optional()', () => {
-      const { node, sourceFile } = parseExpression(
-        'z.coerce.boolean().optional()',
-      );
-      expect(zodToTs(node, sourceFile)).toBe('boolean | undefined');
+      const node = parseExpression('z.coerce.boolean().optional()');
+      expect(zodToTs(node)).toBe('boolean | undefined');
     });
   });
 
   describe('Validations', () => {
     it('should ignore validation methods', () => {
-      const { node, sourceFile } = parseExpression(
-        'z.string().min(1).email().max(10).trim()',
-      );
-      expect(zodToTs(node, sourceFile)).toBe('string');
+      const node = parseExpression('z.string().min(1).email().max(10).trim()');
+      expect(zodToTs(node)).toBe('string');
     });
 
     it('should ignore validation but keep optional', () => {
-      const { node, sourceFile } = parseExpression(
-        'z.string().min(1).optional()',
-      );
-      expect(zodToTs(node, sourceFile)).toBe('string | undefined');
+      const node = parseExpression('z.string().min(1).optional()');
+      expect(zodToTs(node)).toBe('string | undefined');
     });
 
     it('should ignore .transform()', () => {
-      // transform後の型推論は複雑なので、一旦入力型(string)を維持する挙動が期待される
-      // または any になるかもしれないが、現状の実装では内側(string)を返す
-      const { node, sourceFile } = parseExpression(
-        'z.string().transform(s => s.length)',
-      );
-      expect(zodToTs(node, sourceFile)).toBe('string');
+      const node = parseExpression('z.string().transform(s => s.length)');
+      expect(zodToTs(node)).toBe('string');
     });
   });
 
   describe('Collections', () => {
     it('should convert z.enum', () => {
-      const { node, sourceFile } = parseExpression("z.enum(['a', 'b'])");
-      expect(zodToTs(node, sourceFile)).toBe('"a" | "b"');
+      const node = parseExpression("z.enum(['a', 'b'])");
+      // Note: ts-morph might add spaces.
+      expect(zodToTs(node).replace(/\s/g, '')).toBe('"a"|"b"');
     });
 
     it('should convert z.literal', () => {
-      expect(
-        zodToTs(
-          parseExpression('z.literal("hello")').node,
-          parseExpression('').sourceFile,
-        ),
-      ).toBe('"hello"');
-      expect(
-        zodToTs(
-          parseExpression('z.literal(123)').node,
-          parseExpression('').sourceFile,
-        ),
-      ).toBe('123');
-      expect(
-        zodToTs(
-          parseExpression('z.literal(true)').node,
-          parseExpression('').sourceFile,
-        ),
-      ).toBe('true');
+      expect(zodToTs(parseExpression('z.literal("hello")'))).toBe('"hello"');
+      expect(zodToTs(parseExpression('z.literal(123)'))).toBe('123');
+      expect(zodToTs(parseExpression('z.literal(true)'))).toBe('true');
     });
 
     it('should convert z.array(z.string())', () => {
-      const { node, sourceFile } = parseExpression('z.array(z.string())');
-      expect(zodToTs(node, sourceFile)).toBe('string[]');
+      const node = parseExpression('z.array(z.string())');
+      expect(zodToTs(node)).toBe('string[]');
     });
 
     it('should convert z.string().array()', () => {
-      const { node, sourceFile } = parseExpression('z.string().array()');
-      expect(zodToTs(node, sourceFile)).toBe('string[]');
+      const node = parseExpression('z.string().array()');
+      expect(zodToTs(node)).toBe('string[]');
     });
 
     it('should convert z.record', () => {
-      const { node, sourceFile } = parseExpression('z.record(z.number())');
-      expect(zodToTs(node, sourceFile)).toBe('Record<string, number>');
+      const node = parseExpression('z.record(z.number())');
+      expect(zodToTs(node)).toBe('Record<string, number>');
     });
 
     it('should convert z.tuple', () => {
-      const { node, sourceFile } = parseExpression(
-        'z.tuple([z.string(), z.number()])',
-      );
-      expect(zodToTs(node, sourceFile)).toBe('[string, number]');
+      const node = parseExpression('z.tuple([z.string(), z.number()])');
+      expect(zodToTs(node).replace(/\s/g, '')).toBe('[string,number]');
     });
 
     it('should convert z.union', () => {
-      const { node, sourceFile } = parseExpression(
-        'z.union([z.string(), z.number()])',
-      );
-      expect(zodToTs(node, sourceFile)).toBe('string | number');
+      const node = parseExpression('z.union([z.string(), z.number()])');
+      expect(zodToTs(node).replace(/\s/g, '')).toBe('string|number');
     });
   });
 
@@ -189,14 +135,15 @@ describe('zodToTs', () => {
           nullableField: z.string().nullable()
         })
       `;
-      const { node, sourceFile } = parseExpression(code);
-      const result = zodToTs(node, sourceFile);
+      const node = parseExpression(code);
+      const result = zodToTs(node);
 
-      // フォーマットは実装依存だが、要素が含まれているか確認
-      expect(result).toContain('name: string');
-      expect(result).toContain('age?: number'); // optional
-      expect(result).toContain('active?: boolean'); // default -> optional
-      expect(result).toContain('nullableField: string | null');
+      // Normalize whitespace for comparison
+      const normalized = result.replace(/\s/g, '');
+      expect(normalized).toContain('name:string');
+      expect(normalized).toContain('age?:number');
+      expect(normalized).toContain('active?:boolean');
+      expect(normalized).toContain('nullableField:string|null');
     });
 
     it('should convert nested object', () => {
@@ -207,8 +154,62 @@ describe('zodToTs', () => {
           })
         })
       `;
-      const { node, sourceFile } = parseExpression(code);
-      expect(zodToTs(node, sourceFile)).toMatch(/{ user: { id: string } }/);
+      const node = parseExpression(code);
+      const result = zodToTs(node);
+      expect(result.replace(/\s/g, '')).toMatch(/{user:{id:string}}/);
     });
+  });
+});
+
+describe('Complex Scenarios', () => {
+  it('should resolve schema from variable reference', () => {
+    const sourceFile = project.createSourceFile(
+      'test_ref.ts',
+      `
+        import { z } from 'zod';
+        const stringSchema = z.string().min(1);
+        const schema = z.object({
+          name: stringSchema,
+          age: z.number()
+        });
+      `,
+      { overwrite: true },
+    );
+    const declaration = sourceFile.getVariableDeclaration('schema');
+    const node = declaration?.getInitializer() as Expression;
+    const result = zodToTs(node);
+    expect(result).toContain('name: string');
+    expect(result).toContain('age: number');
+  });
+
+  it('should handle aliased zod import', () => {
+    const sourceFile = project.createSourceFile(
+      'test_alias.ts',
+      `
+        import { z as customZ } from 'zod';
+        const schema = customZ.array(customZ.string());
+      `,
+      { overwrite: true },
+    );
+    const declaration = sourceFile.getVariableDeclaration('schema');
+    const node = declaration?.getInitializer() as Expression;
+    expect(zodToTs(node)).toBe('string[]');
+  });
+
+  it('should handle aliased zod import with object', () => {
+    const sourceFile = project.createSourceFile(
+      'test_alias_obj.ts',
+      `
+        import { z as customZ } from 'zod';
+        const schema = customZ.object({
+          id: customZ.number()
+        });
+      `,
+      { overwrite: true },
+    );
+    const declaration = sourceFile.getVariableDeclaration('schema');
+    const node = declaration?.getInitializer() as Expression;
+    const result = zodToTs(node);
+    expect(result.replace(/\s/g, '')).toBe('{id:number}');
   });
 });


### PR DESCRIPTION
TypeScript AST API (`ts`) を利用していたスキーマ解析ロジックを、全面的に ts-morph に置き換えるリファクタリングを実施。 これにより、開発体験の向上と、より高度で安定した型解析機能を提供します。

この変更により、以下の機能改善とバグ修正が実現されました。

- **変数参照の解決**: インラインで定義されていない、他の変数で定義されたZodスキーマを解決できるようになりました。 (例: `const nameSchema = z.string(); const user = z.object({ name: nameSchema });`)

- **Zodエイリアス対応**: `import { z as customZ } from 'zod'` のようにエイリアスでインポートされたZodインスタンスを正しく解析できるようになりました。

- **安定性の向上**:

  シンボル解決時の循環参照によって発生していた無限ループのバグを修正しました。オブジェクト参照の代わりに、ファイルパスとノード位置を組み合わせ たキーで循環参照を検出することで、より堅牢な解析を実現しています。

併せて、`generator.ts`など、このモジュールに依存する箇所のAST解析処理もts-morph APIに更新しました。